### PR TITLE
Add People and Links collections

### DIFF
--- a/src/collections/Links.ts
+++ b/src/collections/Links.ts
@@ -1,0 +1,46 @@
+import { CollectionConfig } from 'payload/types';
+import checkRole from '../lib/checkRole';
+
+const Links: CollectionConfig = {
+	slug: 'links',
+	admin: {
+		useAsTitle: 'kind',
+		description: 'Links to other platforms',
+	},
+	access: {
+		read: () => true,
+		create: ({ req }) => checkRole(req, ['developer']),
+		update: ({ req }) => checkRole(req, ['developer']),
+		delete: ({ req }) => checkRole(req, ['developer']),
+	},
+	fields: [
+		{
+			name: 'kind',
+			label: 'Kind',
+			type: 'select',
+			required: true,
+			options: [
+				'website',
+				'discord',
+				'github',
+				'linkedin',
+				'x',
+				'mastodon',
+				'instagram',
+				'facebook',
+				'youtube',
+				'twitch',
+				'linktree',
+				'other',
+			],
+		},
+		{
+			name: 'url',
+			label: 'URL',
+			type: 'text',
+			required: true,
+		},
+	],
+};
+
+export default Links;

--- a/src/collections/People.ts
+++ b/src/collections/People.ts
@@ -1,0 +1,51 @@
+import { CollectionConfig } from 'payload/types';
+import checkRole from '../lib/checkRole';
+
+const People: CollectionConfig = {
+	slug: 'people',
+	admin: {
+		useAsTitle: 'nickname',
+		description: 'People who are related to projects',
+	},
+	labels: {
+		singular: 'Person',
+		plural: 'People',
+	},
+	access: {
+		read: () => true,
+		create: ({ req }) => checkRole(req, ['developer']),
+		update: ({ req }) => checkRole(req, ['developer']),
+		delete: ({ req }) => checkRole(req, ['superadmin']),
+	},
+	fields: [
+		{
+			name: 'nickname',
+			label: 'Name',
+			type: 'text',
+			required: true,
+		},
+		{
+			name: 'role',
+			label: 'Role',
+			type: 'text',
+			required: true,
+		},
+		{
+			name: 'image',
+			label: 'Image',
+			type: 'relationship',
+			relationTo: 'media',
+			required: false,
+		},
+		{
+			name: 'links',
+			label: 'Links',
+			type: 'relationship',
+			relationTo: 'links',
+			hasMany: true,
+			required: false,
+		},
+	],
+};
+
+export default People;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -22,6 +22,8 @@ import EventMedia from './collections/EventMedia';
 import Forms from './collections/Forms';
 import FormSubmissions from './collections/FormSubmissions';
 import Fanmerch from './collections/Fanmerch';
+import People from './collections/People';
+import Links from './collections/Links';
 
 // Components
 /* eslint-disable import/extensions */
@@ -61,7 +63,8 @@ export default buildConfig({
 	],
 	rateLimit: {
 		trustProxy: true,
-		skip: (req) => req.header('X-RateLimit-Bypass') === process.env.PAYLOAD_BYPASS_RATE_LIMIT_KEY,
+		skip: (req) => req.header('X-RateLimit-Bypass')
+			=== process.env.PAYLOAD_BYPASS_RATE_LIMIT_KEY,
 	},
 	admin: {
 		bundler: webpackBundler(),
@@ -97,11 +100,10 @@ export default buildConfig({
 		Forms,
 		FormSubmissions,
 		Fanmerch,
+		People,
+		Links,
 	],
-	globals: [
-		FeaturedProjects,
-		Notice,
-	],
+	globals: [FeaturedProjects, Notice],
 	plugins: [
 		cloudStorage({
 			enabled: process.env.NODE_ENV === 'production',
@@ -109,17 +111,23 @@ export default buildConfig({
 				media: {
 					adapter,
 					prefix: 'media',
-					generateFileURL: ({ filename, prefix }) => `${process.env.S3_PUBLIC_URL}/${prefix ? `${prefix}/` : ''}${filename}`,
+					generateFileURL: ({ filename, prefix }) => `${process.env.S3_PUBLIC_URL}/${
+						prefix ? `${prefix}/` : ''
+					}${filename}`,
 				},
 				'submission-media': {
 					adapter,
 					prefix: 'submissions',
-					generateFileURL: ({ filename, prefix }) => `${process.env.S3_PUBLIC_URL}/${prefix ? `${prefix}/` : ''}${filename}`,
+					generateFileURL: ({ filename, prefix }) => `${process.env.S3_PUBLIC_URL}/${
+						prefix ? `${prefix}/` : ''
+					}${filename}`,
 				},
 				'event-media': {
 					adapter,
 					prefix: 'event-media',
-					generateFileURL: ({ filename, prefix }) => `${process.env.S3_PUBLIC_URL}/${prefix ? `${prefix}/` : ''}${filename}`,
+					generateFileURL: ({ filename, prefix }) => `${process.env.S3_PUBLIC_URL}/${
+						prefix ? `${prefix}/` : ''
+					}${filename}`,
 				},
 			},
 		}),


### PR DESCRIPTION
This pull request adds the People and Links collections to the project. The People collection is for storing information about individuals related to projects, including their name, role, image, and links. The Links collection is for storing links to other platforms, such as websites, social media profiles, and more. These collections will enhance the functionality and data management of the project.